### PR TITLE
Add networkidle2 while visiting profiles

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -135,7 +135,7 @@ const scrapeLinkedIn = async (data) => {
 
         //Visit activity page
         await page.goto(profileLink + "/detail/recent-activity", {
-          waitUntil: ["domcontentloaded"],
+          waitUntil: ["domcontentloaded", "networkidle2"],
         });
         //Find time of last activities of a user(likes, comments, posts)
         const individualActivities = await page.evaluate(() => {


### PR DESCRIPTION
## Description
Visiting the profile activities page is too fast after #30. The page changes before the dynamic content loads. This leads to activity not being scraped. The solution is to wait until `networkidle2` on the activity page for dynamic content to get loaded (mentioned in [this](https://github.com/ayushjainrksh/conactivity/pull/30#discussion_r498760440) review).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update