### PR TITLE
Fix selector on LinkedIn activity page

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -147,12 +147,12 @@ const scrapeLinkedIn = async (data) => {
           let timeOfActivity = [];
           if (
             document.querySelectorAll(
-              "div.feed-shared-actor__meta.relative > span.feed-shared-actor__sub-description.t-12.t-black--light.t-normal > div > span.visually-hidden"
+              "div.feed-shared-actor__meta.relative > span.feed-shared-actor__sub-description.t-12.t-black--light.t-normal > span > span.visually-hidden"
             )
           ) {
             document
               .querySelectorAll(
-                "div.feed-shared-actor__meta.relative > span.feed-shared-actor__sub-description.t-12.t-black--light.t-normal > div > span.visually-hidden"
+                "div.feed-shared-actor__meta.relative > span.feed-shared-actor__sub-description.t-12.t-black--light.t-normal > span > span.visually-hidden"
               )
               .forEach((item) => {
                 if (item.innerHTML) {


### PR DESCRIPTION
## Description

The CSS selector for selecting LinkedIn activity on the activity page has been changed. Because of this change, the script was unable to scrape any activity. Changing `div` to `span` solved the problem. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
