### PR TITLE
Minor fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Try it out!
 ### Usage
 
 - Clone the repo.
-  #### `git clone https://github.com/ayushjainrksh/linkedin-scraper.git`
+  #### `https://github.com/ayushjainrksh/conactivity.git`
 - Navigate to the cloned repo.
   #### `cd conactivity`
 - In the root directory, install dependencies.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Try it out!
 ### Usage
 
 - Clone the repo.
-  #### `https://github.com/ayushjainrksh/conactivity.git`
+  #### `git clone https://github.com/ayushjainrksh/conactivity.git`
 - Navigate to the cloned repo.
   #### `cd conactivity`
 - In the root directory, install dependencies.


### PR DESCRIPTION
## Description

Since the original clone link given was `https://github.com/ayushjainrksh/linkedin-scraper.git`,
the default name of the repo folder created was **`linkedin-scraper`**.

Thus, the **`cd conactivity`** would give the following output:
![2021-02-02-105939_448x41_scrot](https://user-images.githubusercontent.com/32031518/106556641-f6a3a280-6545-11eb-9882-b9b727fee9d1.png)
 
Fixes a small bug (I didn't create an issue since I thought this was not that significant)

Just a simple fix where we change the clone link, so the default folder name created is same as expected.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)